### PR TITLE
Fix link to Oasis CLI

### DIFF
--- a/manage-tokens/staking-and-delegating.md
+++ b/manage-tokens/staking-and-delegating.md
@@ -12,7 +12,7 @@ The Oasis Network is supported by an amazing community of validators and infrast
 
 #### Tools to use for Staking and Delegation
 
-In addition to using the [Oasis CLI](https://app.gitbook.com/@oasisprotocol/s/general/~/drafts/-MMQWgyLljbUORgRYwzo/use-your-tokens/oasis-cli-tools), there are number of wallets, Ledger GUIs and Custodians support staking and delegation on the Oasis Network. Those include:
+In addition to using the [Oasis CLI](https://docs.oasis.dev/general/manage-tokens/oasis-cli-tools), there are number of wallets, Ledger GUIs and Custodians support staking and delegation on the Oasis Network. Those include:
 
 * [Chorus One Anthem](https://anthem.chorus.one/) \(Ledger GUI\)
 * [Bitpie](https://bitpie.com/) \(mobile wallet\)


### PR DESCRIPTION
This PR:
- [x] Fixes the link to the [Oasis CLI docs](https://docs.oasis.dev/general/manage-tokens/oasis-cli-tools)